### PR TITLE
Add Promise.all example to Promise.spread docs

### DIFF
--- a/docs/docs/api/spread.md
+++ b/docs/docs/api/spread.md
@@ -18,6 +18,21 @@ title: .spread
 
 Like calling `.then`, but the fulfillment value _must be_ an array, which is flattened to the formal parameters of the fulfillment handler.
 
+```js
+Promise.alll([
+    fs.readFileAsync("file1.txt"),
+    fs.readFileAsync("file2.txt")
+]).spread(function(file1text, file2text) {
+    if (file1text === file2text) {
+        console.log("files are equal");
+    }
+    else {
+        console.log("files are not equal");
+    }
+});
+```
+
+When chaining `.spread`, returning an array of promises also works:
 
 ```js
 Promise.delay(500).then(function() {
@@ -33,7 +48,7 @@ Promise.delay(500).then(function() {
 });
 ```
 
-If using ES6, the above can be replaced with [.then()](.) and destructuring:
+Note that if using ES6, the above can be replaced with [.then()](.) and destructuring:
 
 ```js
 Promise.delay(500).then(function() {


### PR DESCRIPTION
This PR adds `Promise.all` example usage to `Promise.spread` API documentation as another way of using spread.

Keeps the existing examples intact, just changing the surrounding text to disambiguate the added example.
